### PR TITLE
Suggest removal of vague and redundant statements.

### DIFF
--- a/text/3463-crates-io-policy-update.md
+++ b/text/3463-crates-io-policy-update.md
@@ -42,8 +42,6 @@ We do not allow content or activity on crates.io that:
   countries the Rust Foundation officially operates in
 - is libelous, defamatory, or fraudulent
 - amounts to phishing or attempted phishing
-- infringes any proprietary right of any party, including patent, trademark,
-  trade secret, copyright, right of publicity, or other right
 - unlawfully shares unauthorized product licensing keys, software for
   generating unauthorized product licensing keys, or software for bypassing
   checks for product licensing keys, including extension of a free license
@@ -72,8 +70,6 @@ We do not allow content or activity on crates.io that:
   other names on crates.io for money or other compensation
 - impersonates any person or entity, including through false association with
   crates.io, or by fraudulently misrepresenting your identity or site's purpose
-- is related to inauthentic interactions, such as fake accounts and automated
-  inauthentic activity
 - is using our servers for any form of excessive automated bulk activity, to
   place undue burden on our servers through automated means, or to relay any
   form of unsolicited advertising or solicitation through our servers, such as
@@ -85,7 +81,6 @@ We do not allow content or activity on crates.io that:
 - is not functionally compatible with the cargo build tool (for example, a
   "package" cannot simply be a PNG or JPEG image, a movie file, or a text
   document uploaded directly to the registry)
-- is abusing the package index for purposes it was not intended
 
 You are responsible for using crates.io in compliance with all applicable laws,
 regulations, and all of our policies. These policies may be updated from time to


### PR DESCRIPTION
"is related to inauthentic interactions, such as fake accounts and automated inauthentic activity" - my brain fails to figure out when this would apply. Having a vague statement like that is, arguably, not the Rust way.

"is abusing the package index for purposes it was not intended" is a catch-all policy, which could be applied to just about anything. One could argue, that a library that only works on one specific microcontroller is abuse of crates.io, as people who do not have that controller can not use the library, so it violates crates.io policy. Is that the intent?

"infringes any proprietary right of any party, including patent, trademark, trade secret, copyright, right of publicity, or other right" - this is quite a sketchy thing, as there are plenty of media codecs and other stuff that does that exact thing. Like, all the hundreds of libraries that touch certain popular media formats would all become outlaws. If a copyright holder wishes a violating package be removed, they are free to file a DMCA request (or equivalent) as outlined below in the RFC.